### PR TITLE
Change URLs from unused DiaryDig.org to WarDiaries.WikiLeaks.org. Fixes #3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 afgexplorer
 +++++++++++
 
-This is the Django source code that runs http://diarydig.org, a tool which
+This is the Django source code that runs http://wardiaries.wikileaks.org, a tool which
 enables rich browsing and searching of the WikiLeaks Afghan War Diaries
 document archive.
 

--- a/afg/templates/about.html
+++ b/afg/templates/about.html
@@ -1,7 +1,7 @@
 <div class='about'>
 <p><b>New:</b> Search Iraq and Afghanistan war logs together!</p>
 
-<p><b><a href='/'>DiaryDig.org</a></b> is an independently produced website
+<p><b><a href='/'>WarDiary.WikiLeaks.org</a></b> is an independently produced website
 which provides an easy way to search through the war logs released by <a href='http://wikileaks.org'>Wikileaks</a>, including the <a href='http://wikileaks.org/wiki/Afghan_War_Diary,_2004-2010'>Afghan War Diary</a> and the <a href='http://warlogs.wikileaks.org/'>Iraq War Logs</a>.</p>
 
 <p>From here, you can <a href='{% url afg.search %}'>browse through all of the

--- a/afg/templates/about.html
+++ b/afg/templates/about.html
@@ -1,7 +1,7 @@
 <div class='about'>
 <p><b>New:</b> Search Iraq and Afghanistan war logs together!</p>
 
-<p><b><a href='/'>WarDiary.WikiLeaks.org</a></b> is an independently produced website
+<p><b><a href='/'>WarDiaries.WikiLeaks.org</a></b> is an independently produced website
 which provides an easy way to search through the war logs released by <a href='http://wikileaks.org'>Wikileaks</a>, including the <a href='http://wikileaks.org/wiki/Afghan_War_Diary,_2004-2010'>Afghan War Diary</a> and the <a href='http://warlogs.wikileaks.org/'>Iraq War Logs</a>.</p>
 
 <p>From here, you can <a href='{% url afg.search %}'>browse through all of the

--- a/afg/templates/afg/api.html
+++ b/afg/templates/afg/api.html
@@ -5,8 +5,8 @@
 <p>The Diary Dig API exposes the basic functionality of Diary Dig to developers.  To use, append "json" to the same URL used to display entries or search results, for example:</p>
 
 <pre>
-    http://www.diarydig.org/search/<b>json</b>?q=Obama...
-    http://www.diarydig.org/id/2F8FCFDD-F5CB-9FAB-B96C7574D4BE7364/<b>json</b>
+    http://wardiary.wikileaks.org/search/<b>json</b>?q=Obama...
+    http://wardiary.wikileaks.org/id/2F8FCFDD-F5CB-9FAB-B96C7574D4BE7364/<b>json</b>
 </pre>
 
 <p>Results include all the basic information used to render pages in DiaryDig.  For entry pages, this includes all the information available for that entry, as well as all the phrases that are linked to other documents, and <tt>report_key</tt>'s that reference those documents.  For search pages, this includes search results, facets, and parameters.</p>

--- a/afg/templates/afg/api.html
+++ b/afg/templates/afg/api.html
@@ -5,8 +5,8 @@
 <p>The Diary Dig API exposes the basic functionality of Diary Dig to developers.  To use, append "json" to the same URL used to display entries or search results, for example:</p>
 
 <pre>
-    http://wardiary.wikileaks.org/search/<b>json</b>?q=Obama...
-    http://wardiary.wikileaks.org/id/2F8FCFDD-F5CB-9FAB-B96C7574D4BE7364/<b>json</b>
+    http://wardiaries.wikileaks.org/search/<b>json</b>?q=Obama...
+    http://wardiaries.wikileaks.org/id/2F8FCFDD-F5CB-9FAB-B96C7574D4BE7364/<b>json</b>
 </pre>
 
 <p>Results include all the basic information used to render pages in DiaryDig.  For entry pages, this includes all the information available for that entry, as well as all the phrases that are linked to other documents, and <tt>report_key</tt>'s that reference those documents.  For search pages, this includes search results, facets, and parameters.</p>


### PR DESCRIPTION
The DiaryDig.org site is currently GoDaddy landing page

This pull request changes URLs in API, README, and about page

You also should change the URL in GitHub project description
